### PR TITLE
Fix font size on axis labels

### DIFF
--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -150,7 +150,7 @@ function init (client, d3, $) {
 
   chart.xAxis = d3.axisBottom(xScale)
     .tickFormat(tickFormat)
-    .ticks(4);
+    .ticks(6);
 
   chart.yAxis = d3.axisLeft(yScale)
     .tickFormat(d3.format('d'))
@@ -201,22 +201,26 @@ function init (client, d3, $) {
 
   // create the x axis container
   chart.focus.append('g')
-    .attr('class', 'x axis');
-
+    .attr('class', 'x axis')
+    .style("font-size", "16px");
+    
   // create the y axis container
   chart.focus.append('g')
-    .attr('class', 'y axis');
+    .attr('class', 'y axis')
+    .style("font-size", "16px");
 
   chart.context = chart.charts.append('g')
     .attr('class', 'chart-context');
 
   // create the x axis container
   chart.context.append('g')
-    .attr('class', 'x axis');
+    .attr('class', 'x axis')
+    .style("font-size", "16px");
 
   // create the y axis container
   chart.context.append('g')
-    .attr('class', 'y axis');
+    .attr('class', 'y axis')
+    .style("font-size", "16px");
 
   chart.createBrushedRange = function () {
     var brushedRange = chart.theBrush && d3.brushSelection(chart.theBrush.node()) || null;

--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -164,6 +164,9 @@ function init (client, d3, $) {
     .tickFormat(d3.format('d'))
     .tickValues(tickValues);
 
+  d3.select('tick')
+    .style('z-index', '10000');
+
   // setup a brush
   chart.brush = d3.brushX()
     .on('start', brushStarted)


### PR DESCRIPTION
The new D3 seems to inject the font size in to the axis labels; this overwrites that definition.